### PR TITLE
Renaming clustering param minClusterSize -> minSamplesPerCluster and Renaming Browser title of App

### DIFF
--- a/app/ui.R
+++ b/app/ui.R
@@ -4,6 +4,7 @@ source("modules/quartoReport/quartoReport.R")
 # TODO: update links to point to new docs page
 
 ui <- fluidPage(
+  title = "Phytoclass-App",
   # App title ----
   titlePanel(markdown(paste0(
     "# Phytoplankton-From-Pigments GUI v0.0.1.0 \n",
@@ -86,22 +87,24 @@ ui <- fluidPage(
             )
           )
         ),
-          tabPanel("Run Clustering",
-            markdown(paste0(
-              'Clustering is applied across all pigment samples to ',
-              'differentiate between samples taken under different conditions. ',
-              'A "dynamic tree cut" algorithm is applied to generate the tree.'
-            )),
-            quartoReportUI("cluster",
-              defaultSetupCode = paste(
-                "inputFile <- 'pigments.rds'",
-                "outputFile <- 'clusters.rds'",
-                "minClusterSize <- 14",
-                sep="\n"
-              )
-            )
-            # TODO: download clusters .csv
+        tabPanel("Run Clustering",
+                 markdown(paste0(
+                   'Clustering is applied across all pigment samples to ',
+                   'differentiate between samples taken under different conditions. ',
+                   'A "dynamic tree cut" algorithm is applied to generate the tree.'
+                 )),
+                 quartoReportUI("cluster",
+                                defaultSetupCode = paste(
+                                  "inputFile <- 'pigments.rds'",
+                                  "outputFile <- 'clusters.rds'",
+                                  "minSamplesPerCluster <- 14",
+                                  sep="\n"
+                                )
+                              ),
+                 br(),
+                 downloadButton("downloadClusters", "Download Clusters (.csv)")
           ),
+        
           tabPanel("Inspect a Cluster",
             markdown(paste0(
               "Details about the selected cluster are shown here."

--- a/app/www/cluster.qmd
+++ b/app/www/cluster.qmd
@@ -7,7 +7,7 @@ format:
 params:
   inputFile: "pigments.rds"
   outputFile: "clusters.rds"
-  minClusterSize: 20
+  minSamplesPerCluster: 20
 ---
 
 ```{R}
@@ -35,7 +35,7 @@ print(paste("Data loaded, length:", nrow(pigment_df)))
 
 result <- phytoclass::Cluster(
   pigment_df,
-  params$minClusterSize
+  params$minSamplesPerCluster
 )
 ```
 


### PR DESCRIPTION
Renamed minClusterSize to minSamplesPerCluster consistently across  Shiny app like done in Main package

1. Updated parameter name from minClusterSize to minSamplesPerCluster to maintain consistency between main package and Shiny app.
2. Simplified the app title from a complicated h1 markdown header to a cleaner, more straightforward "Phytoclass-App" for better readability and user experience.

