### PR TITLE
fix: resolve context file path issue and add sample data validation

### DIFF
--- a/app/modules/quartoReport/buildContext.R
+++ b/app/modules/quartoReport/buildContext.R
@@ -5,27 +5,27 @@ library(glue)
 buildContext <- function(inputCode, output, session_id, session_dir){
   # create context file from inputs
   print("reloading environment...")
-
+  
   # Get the code from the text area input
   print(glue("inputCode: {inputCode}"))
   code <- inputCode
-
+  
   # Split the code into individual expressions
   expressions <- strsplit(code, "\n")[[1]]
-
+  
   # Initialize an empty list to store variable declarations
   var_declarations <- list()
-
+  
   execParams <- list()
   execParams$session_dir <- session_dir
-
+  
   # Evaluate each expression and store variable declarations
   for (expr in expressions) {
     # Parse the expression
     parsed_expr <- tryCatch(parse(text = expr),
                             error = function(e) glue("# invalid code '{expr}'")
     )
-
+    
     # Check if the parsed expression is an assignment
     if (
       !is.null(parsed_expr) &&
@@ -49,10 +49,8 @@ buildContext <- function(inputCode, output, session_id, session_dir){
   
   # Generate hash of parameter set
   paramString <- paste0(capture.output(str(contextParams)), collapse = "")
-  hash <- digest(paramString, algo = "sha256")
-
-  # Use hashed filename
-  contextPath <- glue("www/context-{hash}.yaml")
+  
+  contextPath <- file.path(session_dir, "context.yaml")
   write_yaml(contextParams, contextPath)  # TODO: generate better filename (with hash?)
   
   return(contextPath)

--- a/app/www/cluster.qmd
+++ b/app/www/cluster.qmd
@@ -22,10 +22,11 @@ library("glue")
 pigment_df <- readRDS(file.path(params$session_dir, params$inputFile))
 # TODO: validate
 
-# TODO: set index to first column (named samples?)
-# rownames(pigment_df) <- pigment_df[, 1]  # Use the first column as row names
-# df <- df[, -1]  # Remove the first column
-
+# Set row names if unique
+if (anyDuplicated(pigment_df[, 1]) == 0) {
+  rownames(pigment_df) <- pigment_df[, 1]
+  pigment_df <- pigment_df[, -1]
+}
 
 # Update the status based on the length of the data frame
 print(paste("Data loaded, length:", nrow(pigment_df)))


### PR DESCRIPTION
Issues fixed:
  1. Previously, `buildContext.R` was generating the context YAML file in the global `www/` folder,
    while the server was expecting it inside the per-session directory. This mismatch caused issue #25.
    The path is now fixed to ensure context files are written directly into the session folder.
  2. The earlier hashing-based filename strategy caused multiple redundant context files 
    to be generated per module/report, leading to clutter. This has been reverted 
    to a single consistent filename per session.
  3. Additionally, `cluster.qmd` was incorrectly interpreting the first column of input as integers,
    causing a binary encoding error. Added `row.names = 1` equivalent logic to correctly preserve
    sample names as row identifiers during report rendering. Now shiny app can read ME2-S properly

closes #25 