### PR TITLE
Fix: Auto-set row names if first column contains character sample names

### DIFF
--- a/app/www/cluster.qmd
+++ b/app/www/cluster.qmd
@@ -30,10 +30,10 @@ suppressPackageStartupMessages({
 pigment_df <- readRDS(file.path(params$session_dir, params$inputFile))
 # TODO: validate
 
-# Set row names if unique
-if (anyDuplicated(pigment_df[, 1]) == 0) {
-  rownames(pigment_df) <- pigment_df[, 1]
-  pigment_df <- pigment_df[, -1]
+# Set first column as row names if it contains sample names
+if (is.character(pigment_df[[1]])) {
+  rownames(pigment_df) <- pigment_df[[1]]
+  pigment_df <- pigment_df[, -1, drop = FALSE]
 }
 
 # Update the status based on the length of the data frame


### PR DESCRIPTION
This PR adds a conditional check to set row names in the input matrix only if the first column contains character values, which indicate sample names.

Previously, the first column was always treated as sample names and set as row names, even when it contained actual data values. This behavior has been corrected by verifying the column type before setting row names. 