### PR TITLE
Fix: row.names handling, param UI, add clustering bypass

### DIFF
--- a/app/modules/quartoReport/buildContext.R
+++ b/app/modules/quartoReport/buildContext.R
@@ -50,9 +50,6 @@ buildContext <- function(inputCode, bypass_clustering, output, session_id, sessi
   
   contextParams <- execParams
   
-  # Render parameters in UI
-  output$execParamsDisplay <- renderPrint({ contextParams })
-  
   # Generate hash of parameter set
   paramString <- paste0(capture.output(str(contextParams)), collapse = "")
   

--- a/app/modules/quartoReport/buildContext.R
+++ b/app/modules/quartoReport/buildContext.R
@@ -2,7 +2,7 @@ library(yaml)
 library(digest)
 library(glue)
 
-buildContext <- function(inputCode, output, session_id, session_dir){
+buildContext <- function(inputCode, bypass_clustering, output, session_id, session_dir){
   # create context file from inputs
   print("reloading environment...")
   
@@ -40,6 +40,12 @@ buildContext <- function(inputCode, output, session_id, session_dir){
     } else {
       print(glue("error in param expression: '{expr}'"))
     }
+  }
+  
+  if (isTRUE(bypass_clustering)) {
+    execParams$inputFile <- "pigments.rds"
+  } else if (is.null(execParams$inputFile)) {
+    execParams$inputFile <- "clusters.rds"
   }
   
   contextParams <- execParams

--- a/app/modules/quartoReport/quartoReport.R
+++ b/app/modules/quartoReport/quartoReport.R
@@ -11,13 +11,13 @@ source("modules/quartoReport/buildContext.R")
 # === Function to actually render the report =========
 actualRenderReport <- function(
     contextRDSPath, inputCode, output, qmd_path, reportHTMLPath, reportPDFPath, 
-    reportQMDPath, id, session_id, session_dir
+    reportQMDPath, id, session_id, session_dir, bypass_clustering
 ){
   print("rendering....")
   print(glue("inputCode: {inputCode}"))
   
   # Save the context built using the input code
-  contextRDSPath(buildContext(inputCode, output, session_id, session_dir))
+  contextRDSPath(buildContext(inputCode, bypass_clustering, output, session_id, session_dir))
   print(glue("context: {contextRDSPath()}"))
   
   tryCatch({
@@ -109,7 +109,7 @@ actualRenderReport <- function(
 # === Schedules and triggers the report rendering =================================
 renderReport <- function(
     contextRDSPath, setupInputCode, output, qmd_path, reportHTMLPath, id, 
-    reportPDFPath, reportQMDPath, session_id, session_dir
+    reportPDFPath, reportQMDPath, session_id, session_dir, bypass_clustering
 ){
   # renderReport schedules the render for later so that the "generating report..." text shows immediately
   print(glue("generating report '{id}'..."))
@@ -136,7 +136,8 @@ renderReport <- function(
     reportQMDPath,
     id, 
     session_id,
-    session_dir
+    session_dir,
+    bypass_clustering
   )
 }
 
@@ -149,6 +150,12 @@ quartoReportUI <- function(id, defaultSetupCode = "x <- 1"){
     tabPanel("generate report",
     verbatimTextOutput(ns("execParamsDisplay")),
     tags$br(),
+    if (id == "anneal") tagList(
+      checkboxInput(ns("bypass_clustering"),
+        label = "Skip Clustering",
+        value = FALSE
+      )
+    ),
     actionButton(ns("generateButton"), "generate report"),
     
     # Add a loading spinner while output is rendering
@@ -259,7 +266,8 @@ quartoReportServer <- function(id, session_dir = NULL){
         reportPDFPath, 
         reportQMDPath,
         session_id,
-        session_path 
+        session_path,
+        input$bypass_clustering
       )
       reportGenerated(TRUE)
     })

--- a/app/server.R
+++ b/app/server.R
@@ -85,6 +85,10 @@ server <- function(input, output, session) {
         selected_cluster_data$Clust <- NULL
       }
       
+      # Round off numeric values to 4 decimal places
+      is_numeric_col <- sapply(selected_cluster_data, is.numeric)
+      selected_cluster_data[is_numeric_col] <- lapply(selected_cluster_data[is_numeric_col], round, digits = 4)
+      
       write.csv(selected_cluster_data, file, row.names = TRUE)
     }
   )

--- a/app/ui.R
+++ b/app/ui.R
@@ -112,7 +112,7 @@ ui <- fluidPage(
             ),
             downloadButton("downloadCluster", "Download Inspected Cluster CSV")
           ),
-          tabPanel("Run Annealing on a Cluster",
+          tabPanel("Run Annealing",
             markdown(paste0(
               "Simulated annealing is run to solve the least squares ",
               "minimization problem to determine the most likely taxa in the ",

--- a/app/www/anneal.qmd
+++ b/app/www/anneal.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Cluster"
+title: "Annealing"
 format:
   html:
     code-fold: true
@@ -9,10 +9,22 @@ params:
   inputFile: "clusters.rds"
   taxaFile: "taxa.rds"
   outputFile: "anneal.rds"
-  seed: 7683
+  seed: 0
   selected_cluster: 1
   niter: 500
 ---
+
+```{r echo=FALSE, results='asis'}
+library(glue)
+cat(glue("
+- **Input File**: `{params$inputFile}`  
+- **Taxa File**: `{params$taxaFile}`  
+- **Output File**: `{params$outputFile}`  
+- **Selected Cluster**: `{params$selected_cluster}`  
+- **Niter**: `{params$niter}`  
+- **Seed**: `{params$seed}`  
+"))
+```
 
 ```{R}
 #| label: helper functions
@@ -25,7 +37,7 @@ library("glue")
 #| label: load data
 #| code-summary: Load input cluster and taxa matrices
 
-clusters <- readRDS(file.path(params$session_dir, params$inputFile))
+input_data <- readRDS(file.path(params$session_dir, params$inputFile))
 taxa <- readRDS(file.path(params$session_dir, params$taxaFile))
 ```
 
@@ -66,15 +78,17 @@ if (length(dropped_colnames) > 0) {
 #| label: prepare-s-matrix
 #| code-summary: Prepare S matrix
 
-if (params$selected_cluster > length(clusters$cluster.list)){
-  stop("selected cluster is greater than number of clusters")
+if ("cluster.list" %in% names(input_data)) {
+  # Using clustered data
+  if (params$selected_cluster > length(input_data$cluster.list)) {
+    stop("selected cluster is greater than number of clusters")
+  }
+  selectedCluster <- input_data$cluster.list[[params$selected_cluster]]
+  selectedCluster$Clust <- NULL
+} else {
+  # Using raw pigment matrix directly
+  selectedCluster <- input_data
 }
-
-selectedCluster <- clusters$cluster.list[[
-  params$selected_cluster
-]]
-# log_trace("Remove cluster column/label")
-selectedCluster$Clust <- NULL
 ```
 
 ```{R}
@@ -124,7 +138,7 @@ set.seed(params$seed)
 
 Results <- phytoclass::simulated_annealing(
   S = selectedCluster,
-  F = taxa,  # TODO: this isn't working?
+  Fmat = taxa,  # TODO: this isn't working?
   niter = params$niter,  # number of iterations
   # user_defined_min_max = minMaxTable
   # TODO: place to upload table to replace

--- a/app/www/cluster.qmd
+++ b/app/www/cluster.qmd
@@ -11,6 +11,15 @@ params:
   minSamplesPerCluster: 20
 ---
 
+```{r echo=FALSE, results='asis'}
+library(glue)
+cat(glue("
+- **Input File**: `{params$inputFile}`  
+- **Output File**: `{params$outputFile}`  
+- **Min samples per cluster**: `{params$minSamplesPerCluster}`  
+"))
+```
+
 ```{R}
 #| label: helper functions
 #| code-summary: Load required libraries
@@ -30,10 +39,10 @@ suppressPackageStartupMessages({
 pigment_df <- readRDS(file.path(params$session_dir, params$inputFile))
 # TODO: validate
 
-# Set row names if unique
-if (anyDuplicated(pigment_df[, 1]) == 0) {
-  rownames(pigment_df) <- pigment_df[, 1]
-  pigment_df <- pigment_df[, -1]
+# Set first column as row names if it contains sample names
+if (is.character(pigment_df[[1]])) {
+  rownames(pigment_df) <- pigment_df[[1]]
+  pigment_df <- pigment_df[, -1, drop = FALSE]
 }
 
 # Update the status based on the length of the data frame

--- a/app/www/inspectCluster.qmd
+++ b/app/www/inspectCluster.qmd
@@ -10,6 +10,14 @@ params:
   selected_cluster: 1
 ---
 
+```{r echo=FALSE, results='asis'}
+library(glue)
+cat(glue("
+- **Input File**: `{params$inputFile}`  
+- **Selected Cluster**: `{params$selected_cluster}`  
+"))
+```
+
 ```{R}
 #| label: helper functions
 #| code-summary: Load required library


### PR DESCRIPTION
Changes Made:

1. Conditional Row Name Detection:
    -  Sets row names = 1 in the input pigment matrix only if the first column contains character values (i.e., sample names).
    - Prevents misinterpretation of numeric pigment columns as sample names.
2. Clustering Bypass Option:
    - Adds a “Skip clustering” checkbox, visible only in the Anneal Report tab.
    - When enabled, the app directly uses pigments.rds for simulated_annealing() without running clustering.
    - Fixes previous drawback of no ability to use annealing directly without clustering
3. Rounding in Cluster CSV Export
4. Execution Parameter Display Fix: 
    - Properly shows inputCode execution parameters above the rendered report.

closes #31 
closes #29 
closes #14 
closes #10 
closes #22 