### PR TITLE
Replacing pdf report download button with Html report download button

### DIFF
--- a/app/modules/quartoReport/quartoReport.R
+++ b/app/modules/quartoReport/quartoReport.R
@@ -10,7 +10,7 @@ source("modules/quartoReport/buildContext.R")
 
 # === Function to actually render the report =========
 actualRenderReport <- function(
-    contextRDSPath, inputCode, output, qmd_path, reportHTMLPath, reportPDFPath,
+    contextRDSPath, inputCode, output, qmd_path, reportHTMLPath,
     reportQMDPath, id, session_id, session_dir, bypass_clustering
 ){
   print("rendering....")
@@ -57,25 +57,6 @@ actualRenderReport <- function(
       ))
     }
 
-    # === Render PDF report ============================
-    # In actualRenderReport function, modify the system2 calls:
-    withr::with_dir(session_dir, {
-      pdf_output_message <- system2(
-        command = "quarto",
-        args = c(
-          "render",
-          basename(session_qmd_path),
-          "--to", "pdf",
-          "--output", basename(reportPDFPath),
-          "--execute-params", basename(contextRDSPath()),
-          "-P", "session_dir:.",
-          "--execute-dir", "."
-        ),
-        stdout = TRUE,
-        stderr = TRUE
-      )
-    })
-
     # Copy the QMD file for download
     file.copy(qmd_path, reportQMDPath, overwrite = TRUE)
 
@@ -109,7 +90,7 @@ actualRenderReport <- function(
 # === Schedules and triggers the report rendering =================================
 renderReport <- function(
     contextRDSPath, setupInputCode, output, qmd_path, reportHTMLPath, id,
-    reportPDFPath, reportQMDPath, session_id, session_dir, bypass_clustering
+    reportQMDPath, session_id, session_dir, bypass_clustering
 ){
   # renderReport schedules the render for later so that the "generating report..." text shows immediately
   print(glue("generating report '{id}'..."))
@@ -132,7 +113,6 @@ renderReport <- function(
     output,
     qmd_path,
     reportHTMLPath,
-    reportPDFPath,
     reportQMDPath,
     id,
     session_id,
@@ -197,7 +177,7 @@ quartoReportUI <- function(id, defaultSetupCode = "x <- 1"){
       # TODO:
       markdown("Use the buttons below to download results from the report."),
       # actionButton(ns("downloadRDSButton"), "download .rds"),
-      downloadButton(ns("downloadPDFButton"), "Download PDF"),
+      downloadButton(ns("downloadHTMLButton"), "Download HTML"),
       downloadButton(ns("downloadQMDButton"), "Download QMD"),
       if (id == "anneal") {
         tagList(
@@ -238,7 +218,6 @@ quartoReportServer <- function(id, session_dir = NULL){
   # Ensure download_reports folder exists
   download_reports_dir <- file.path(session_path, "download_reports")
   dir.create(download_reports_dir, showWarnings = FALSE, recursive = TRUE)
-  reportPDFPath <- file.path(session_path, glue("{id}.pdf"))
 
   reportQMDPath <- file.path(download_reports_dir, glue("{id}-report.qmd"))
 
@@ -277,7 +256,6 @@ quartoReportServer <- function(id, session_dir = NULL){
         qmd_path,
         reportHTMLPath,
         id,
-        reportPDFPath,
         reportQMDPath,
         session_id,
         session_path,
@@ -285,18 +263,18 @@ quartoReportServer <- function(id, session_dir = NULL){
       )
       reportGenerated(TRUE)
     })
-
-    # === Download Handler for PDF report ===================================
-    output$downloadPDFButton <- downloadHandler(
+    
+    # === Download Handler for HTML Report ===============================
+    output$downloadHTMLButton <- downloadHandler(
       filename = function() {
-        paste0(id, "-report-", Sys.Date(), ".pdf")
+        paste0(id, "-report-", Sys.Date(), ".html")
       },
       content = function(file) {
         req(reportGenerated())
-        if(file.exists(reportPDFPath)) {
-          file.copy(reportPDFPath, file)
+        if (file.exists(reportHTMLPath)) {
+          file.copy(reportHTMLPath, file)
         } else {
-          showNotification("PDF not found. Generate report first.", type = "error")
+          showNotification("HTML not found. Generate report first.", type = "error")
         }
       }
     )
@@ -316,6 +294,7 @@ quartoReportServer <- function(id, session_dir = NULL){
       }
     )
 
+    # === Download Handler for TAXA Result ===============================
     output$downloadTaxaCSVButton <- downloadHandler(
       filename = function() {
         paste0(id, "_taxa_estimates_", Sys.Date(), ".csv")
@@ -333,6 +312,7 @@ quartoReportServer <- function(id, session_dir = NULL){
       }
     )
 
+    # === Download Handler for F Matrix Result ===============================
     output$downloadFMatrixCSVButton <- downloadHandler(
       filename = function() {
         paste0(id, "_fmatrix_", Sys.Date(), ".csv")
@@ -347,6 +327,7 @@ quartoReportServer <- function(id, session_dir = NULL){
       }
     )
 
+    # === Download Handler for MAE Result ===============================
     output$downloadMAECSVButton <- downloadHandler(
       filename = function() {
         paste0(id, "_MAE_", Sys.Date(), ".csv")
@@ -369,4 +350,3 @@ quartoReportServer <- function(id, session_dir = NULL){
     # TODO: download report button controller
   })
 }
-

--- a/app/www/anneal.qmd
+++ b/app/www/anneal.qmd
@@ -2,6 +2,7 @@
 title: "Annealing"
 format:
   html:
+    self-contained: true
     code-fold: true
     standalone: true
 params:
@@ -236,59 +237,55 @@ print(Results$Figure)
 #| label: sankey-diagram
 #| code-summary: Sankey diagram of pigment flow into phytoplankton groups
 
-if (knitr::is_html_output()) {
+# Aggregate pigment totals across samples
+pigment_totals <- colSums(selectedCluster)
 
-  # Aggregate pigment totals across samples
-  pigment_totals <- colSums(selectedCluster)
+# Multiply by F matrix to allocate to classes
+F <- Results$`F matrix`
+common_pigments <- intersect(names(pigment_totals), colnames(F))
 
-  # Multiply by F matrix to allocate to classes
-  F <- Results$`F matrix`
-  common_pigments <- intersect(names(pigment_totals), colnames(F))
-
-  if (length(common_pigments) == 0) {
-    stop("No common pigments found between S and F matrix")
-  }
-
-  # Slice relevant portions
-  pigment_totals <- pigment_totals[common_pigments]
-  F <- F[, common_pigments, drop=FALSE]
-
-  # Compute pigment contribution to each phyto class
-  flow_matrix <- as.matrix(F) %*% diag(pigment_totals)
-  colnames(flow_matrix) <- names(pigment_totals)
-  flow_df <- as.data.frame(flow_matrix)
-  flow_df$class <- rownames(F)
-
-  # Convert wide to long format: pigment -> class, weight = value
-  sankey_data <- flow_df |>
-    tidyr::pivot_longer(
-      -class, 
-      names_to = "pigment", 
-      values_to = "value"
-    ) |>
-    filter(value > 0)
-
-  # Create node and link structure
-  nodes <- unique(c(sankey_data$pigment, sankey_data$class))
-  node_df <- data.frame(name = nodes)
-
-  sankey_data$source <- match(sankey_data$pigment, node_df$name) - 1
-  sankey_data$target <- match(sankey_data$class, node_df$name) - 1
-
-  # Render
-  sankeyNetwork(
-    Links = sankey_data[, c("source", "target", "value")],
-    Nodes = node_df,
-    Source = "source",
-    Target = "target",
-    Value = "value",
-    NodeID = "name",
-    fontSize = 12,
-    nodeWidth = 30,
-    sinksRight = FALSE
-  )
+if (length(common_pigments) == 0) {
+  stop("No common pigments found between S and F matrix")
 }
 
+# Slice relevant portions
+pigment_totals <- pigment_totals[common_pigments]
+F <- F[, common_pigments, drop=FALSE]
+
+# Compute pigment contribution to each phyto class
+flow_matrix <- as.matrix(F) %*% diag(pigment_totals)
+colnames(flow_matrix) <- names(pigment_totals)
+flow_df <- as.data.frame(flow_matrix)
+flow_df$class <- rownames(F)
+
+# Convert wide to long format: pigment -> class, weight = value
+sankey_data <- flow_df |>
+  tidyr::pivot_longer(
+    -class, 
+    names_to = "pigment", 
+    values_to = "value"
+  ) |>
+  filter(value > 0)
+
+# Create node and link structure
+nodes <- unique(c(sankey_data$pigment, sankey_data$class))
+node_df <- data.frame(name = nodes)
+
+sankey_data$source <- match(sankey_data$pigment, node_df$name) - 1
+sankey_data$target <- match(sankey_data$class, node_df$name) - 1
+
+# Render
+sankeyNetwork(
+  Links = sankey_data[, c("source", "target", "value")],
+  Nodes = node_df,
+  Source = "source",
+  Target = "target",
+  Value = "value",
+  NodeID = "name",
+  fontSize = 12,
+  nodeWidth = 30,
+  sinksRight = FALSE
+)
 ```
 
 ```{R}

--- a/app/www/cluster.qmd
+++ b/app/www/cluster.qmd
@@ -2,6 +2,7 @@
 title: "Cluster"
 format:
   html:
+    self-contained: true
     code-fold: true
     standalone: true
 params:
@@ -75,9 +76,7 @@ plot(result$cluster.plot)
 #| label: interactive-cluster-plot
 #| code-summary: Interactive cluster plot
 
-#interactive plot won't be rendered into pdf
-if (knitr::is_html_output()) {
-  dendro_data <- ggdendro::dendro_data(result$cluster.plot)
+dendro_data <- ggdendro::dendro_data(result$cluster.plot)
 
 # Convert hclust to dendrogram data
 dendro_data <- ggdendro::dendro_data(result$cluster.plot)
@@ -90,7 +89,6 @@ p <- ggplot(segment(dendro_data)) +
 
 # Convert to plotly
 plotly::ggplotly(p)
-}
 ```
 
 ```{R}

--- a/app/www/inspectCluster.qmd
+++ b/app/www/inspectCluster.qmd
@@ -2,6 +2,7 @@
 title: "Cluster Inspector"
 format:
   html:
+    self-contained: true
     code-fold: true
     standalone: true
 params:


### PR DESCRIPTION
Replaced the PDF report download button with an HTML report download button.

Reason for Change:
As per Tyler's recommendation, PDF generation requires the tinytex dependency, which adds unnecessary overhead and complexity. Switching to HTML reports avoids this issue.

Benefits of HTML reports:
  1. No need for additional dependencies like tinytex
  2. Faster report generation
  3. Supports interactive diagrams (which are not possible in PDFs)